### PR TITLE
Pathauto context updates

### DIFF
--- a/config/install/pathauto.pattern.pattern_for_all_basic_page_paths.yml
+++ b/config/install/pathauto.pattern.pattern_for_all_basic_page_paths.yml
@@ -9,7 +9,7 @@ type: 'canonical_entities:node'
 pattern: '[node:menu-link:parent:url:path]/[node:title]'
 selection_criteria:
   6cec4fa0-67bb-49ee-9be3-3a5cab8b7f86:
-    id: node_type
+    id: 'entity_bundle:node'
     bundles:
       page: page
     negate: false

--- a/osu_standard.install
+++ b/osu_standard.install
@@ -40,6 +40,21 @@ function osu_standard_install($is_syncing) {
 }
 
 /**
+ * Ensure that our paths have updated.
+ */
+function osu_standard_update_9013(&$sandbox) {
+  $config = \Drupal::configFactory();
+  $path_auto_pattern = $config->getEditable('pathauto.pattern.pattern_for_all_basic_page_paths');
+  $selection_criteria = $path_auto_pattern->get('selection_criteria');
+  $selection_criteria_id = $selection_criteria[array_key_first($selection_criteria)]['id'];
+  if ($selection_criteria_id === 'node_type') {
+    $selection_criteria[array_key_first($selection_criteria)]['id'] = "entity_bundle:node";
+  }
+  $path_auto_pattern->set('selection_criteria', $selection_criteria);
+  $path_auto_pattern->save();
+}
+
+/**
  * Enable easy_breadcrumb
  */
 function osu_standard_update_9012(&$sandbox) {

--- a/osu_standard.install
+++ b/osu_standard.install
@@ -42,7 +42,7 @@ function osu_standard_install($is_syncing) {
 /**
  * Ensure that our paths have updated.
  */
-function osu_standard_update_9013(&$sandbox) {
+function osu_standard_update_9014(&$sandbox) {
   $config = \Drupal::configFactory();
   $path_auto_pattern = $config->getEditable('pathauto.pattern.pattern_for_all_basic_page_paths');
   $selection_criteria = $path_auto_pattern->get('selection_criteria');


### PR DESCRIPTION
minor update to configs and an update hook to ensure all existing sites have been updated, Pathauth had this update before but if we created a new site after that Pathauto update they would be miss-configured.