### PR TITLE
Add storage field configs.

### DIFF
--- a/config/install/field.storage.node.field_osu_organizations.yml
+++ b/config/install/field.storage.node.field_osu_organizations.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - taxonomy
+id: node.field_osu_organizations
+field_name: field_osu_organizations
+entity_type: node
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/osu_standard.info.yml
+++ b/osu_standard.info.yml
@@ -134,11 +134,10 @@ dependencies:
   - webform_ui
   # Custom Modules
   - osu_bootstrap_layout_builder
-  - osu_default_content
-  - osu_profile
-  - osu_roles
   - osu_ckeditor_plugins
+  - osu_default_content
   - osu_media
+  - osu_roles
   - osu_seckit
 themes:
   # Core Themes

--- a/osu_standard.install
+++ b/osu_standard.install
@@ -2,6 +2,7 @@
 
 use Drupal\Core\Config\FileStorage;
 use Drupal\Core\Entity\EntityStorageException;
+use Drupal\field\Entity\FieldStorageConfig;
 use Drupal\shortcut\Entity\Shortcut;
 use Drupal\taxonomy\Entity\Vocabulary;
 use Drupal\user\Entity\Role;
@@ -38,12 +39,32 @@ function osu_standard_install($is_syncing) {
   $page_cache->set('cache.page.max_age', 31536000);
   $page_cache->save();
 
-  $vocabulary=Vocabulary::create(array(
-    'vid'=>'osu_organization',
-    'name'=>'Organization',
-    'description'=>'A set of tags to represent the structure of your organization. e.g. Schools and/or Units',
-  ))->save();
+  Vocabulary::create([
+    'vid' => 'osu_organization',
+    'name' => 'Organization',
+    'description' => 'A set of tags to represent the structure of your organization. e.g. Schools and/or Units',
+  ])->save();
 
+}
+
+/**
+ * Install OSU Story module.
+ */
+function osu_standard_update_9019(&$sandbox) {
+  $install_profile_path = \Drupal::service('module_handler')
+    ->getModule('osu_standard')
+    ->getPath();
+  $install_profile_config_path = realpath($install_profile_path . '/config/install');
+  $file_source = new FileStorage($install_profile_config_path);
+  if (is_null(FieldStorageConfig::load('field.storage.node.field_tags'))) {
+    FieldStorageConfig::create($file_source->read('field.storage.node.field_tags'));
+  }
+  if (is_null(FieldStorageConfig::load('field.storage.node.field_osu_organizations'))) {
+    FieldStorageConfig::create($file_source->read('field.storage.node.field_osu_organizations'));
+  }
+  \Drupal::service('module_installer')->install([
+    'osu_story',
+  ], TRUE);
 }
 
 /**
@@ -77,11 +98,11 @@ function osu_standard_update_9017(&$sandbox) {
  * Add vocabulary to existing sites.
  */
 function osu_standard_update_9016(&$sandbox) {
-  $vocabulary=Vocabulary::create(array(
-    'vid'=>'osu_organization',
-    'name'=>'Organization',
-    'description'=>'A set of tags to represent the structure of your organization. e.g. Schools and/or Units',
-  ))->save();
+  Vocabulary::create([
+    'vid' => 'osu_organization',
+    'name' => 'Organization',
+    'description' => 'A set of tags to represent the structure of your organization. e.g. Schools and/or Units',
+  ])->save();
 }
 
 /**

--- a/osu_standard.profile
+++ b/osu_standard.profile
@@ -46,5 +46,7 @@ function osu_standard_install_tasks(&$install_state) {
 function osu_standard_default_modules(array &$install_state) {
   \Drupal::service('module_installer')->install([
     'osu_block_types',
+    'osu_story',
+    'osu_profile'
   ], TRUE);
 }


### PR DESCRIPTION
Update hook to ensure field storage types are created before adding the module.
Move module requirements into post install as the site needs to ensure that the field.storage configs are imported before using the site.