### PR TITLE
Block Content Permissions in 10.1

### DIFF
--- a/config/install/user.role.architect.yml
+++ b/config/install/user.role.architect.yml
@@ -77,6 +77,7 @@ is_admin: null
 permissions:
   - 'access administration pages'
   - 'access any webform configuration'
+  - 'access block library'
   - 'access content'
   - 'access content overview'
   - 'access contextual links'
@@ -101,6 +102,9 @@ permissions:
   - 'administer CAPTCHA settings'
   - 'administer account settings'
   - 'administer ap style settings'
+  - 'administer block classes'
+  - 'administer block content'
+  - 'administer block types'
   - 'administer block visibility groups'
   - 'administer block_content display'
   - 'administer block_content fields'

--- a/config/install/user.role.dx_administrator.yml
+++ b/config/install/user.role.dx_administrator.yml
@@ -86,6 +86,7 @@ is_admin: null
 permissions:
   - 'access administration pages'
   - 'access any webform configuration'
+  - 'access block library'
   - 'access content'
   - 'access content overview'
   - 'access contextual links'
@@ -113,6 +114,8 @@ permissions:
   - 'administer account settings'
   - 'administer ap style settings'
   - 'administer block classes'
+  - 'administer block content'
+  - 'administer block types'
   - 'administer block visibility groups'
   - 'administer block_content display'
   - 'administer block_content fields'

--- a/config/install/user.role.manage_blocks.yml
+++ b/config/install/user.role.manage_blocks.yml
@@ -5,6 +5,7 @@ dependencies:
   module:
     - block
     - block_class
+    - block_content
     - block_visibility_groups
     - captcha
     - contextual
@@ -16,8 +17,11 @@ label: 'Manage Blocks'
 weight: -5
 is_admin: null
 permissions:
+  - 'access block library'
   - 'access contextual links'
   - 'administer block classes'
+  - 'administer block content'
+  - 'administer block types'
   - 'administer block visibility groups'
   - 'administer blocks'
   - 'administer simple_popup_blocks'

--- a/osu_standard.install
+++ b/osu_standard.install
@@ -48,6 +48,30 @@ function osu_standard_install($is_syncing) {
 }
 
 /**
+ * Update Roles to now manage Block Content.
+ */
+function osu_standard_update_10001(&$sandbox) {
+  $dx_administrator = Role::load('dx_administrator');
+  $dx_administrator->grantPermission('access block library');
+  $dx_administrator->grantPermission('administer block content');
+  $dx_administrator->grantPermission('administer block types');
+  $dx_administrator->save();
+
+  $architect = Role::load('architect');
+  $architect->grantPermission('access block library');
+  $architect->grantPermission('administer block classes');
+  $architect->grantPermission('administer block contents');
+  $architect->grantPermission('administer block types');
+  $architect->save();
+
+  $manage_blocks = Role::load('manage_blocks');
+  $manage_blocks->grantPermission('access block library');
+  $manage_blocks->grantPermission('administer block content');
+  $manage_blocks->grantPermission('administer block types');
+  $manage_blocks->save();
+}
+
+/**
  * Updating paddings and margins.
  */
 function osu_standard_update_10000(&$sandbox) {


### PR DESCRIPTION
Update roles with the permissions to also manage all the content created for blocks.