### PR TITLE
Set default 404 page option for Madrone Theme

### DIFF
--- a/osu_standard.install
+++ b/osu_standard.install
@@ -1287,3 +1287,15 @@ function osu_standard_update_10004(&$sandbox) {
     ->set('page.404', '')
     ->save();
 }
+
+/**
+ * Set the Default option for Madrone Theme 404 page.
+ */
+function osu_standard_update_10005(&$sandbox) {
+  $config_factory = \Drupal::configFactory();
+  $editable_config = $config_factory->getEditable('system.theme');
+  $default_theme = $editable_config->get('default');
+  $theme_config = $config_factory->getEditable("{$default_theme}.settings");
+  $theme_config->set('madrone_use_default_404', TRUE);
+  $theme_config->save();
+}


### PR DESCRIPTION
A function has been added in the osu_standard.install file to set the default 404 page for the Madrone Theme. This update is part of the osu_standard_update_10005. The configuration settings for the default theme have been edited to implement this change.