### PR TITLE
Add 'use text format webform_default' permission to user roles

### DIFF
--- a/config/install/user.role.architect.yml
+++ b/config/install/user.role.architect.yml
@@ -280,6 +280,7 @@ permissions:
   - 'use text format basic_html'
   - 'use text format full_html'
   - 'use text format restricted_html'
+  - 'use text format webform_default'
   - 'use views bulk edit'
   - 'view all media revisions'
   - 'view all revisions'

--- a/config/install/user.role.dx_administrator.yml
+++ b/config/install/user.role.dx_administrator.yml
@@ -310,6 +310,7 @@ permissions:
   - 'use text format basic_html'
   - 'use text format full_html'
   - 'use text format restricted_html'
+  - 'use text format webform_default'
   - 'use views bulk edit'
   - 'view acquia connector toolbar'
   - 'view all media revisions'

--- a/config/install/user.role.manage_webforms.yml
+++ b/config/install/user.role.manage_webforms.yml
@@ -1,4 +1,3 @@
-
 uuid: 440be9f9-9eba-474b-bb44-902a90b83c59
 langcode: en
 status: true
@@ -37,6 +36,7 @@ permissions:
   - 'edit webform twig'
   - 'edit webform variants'
   - 'skip CAPTCHA'
+  - 'use text format webform_default'
   - 'view any webform submission'
   - 'view own webform submission'
   - 'view webform submissions own node'

--- a/osu_standard.install
+++ b/osu_standard.install
@@ -1364,3 +1364,21 @@ function osu_standard_update_10008(&$sandbox): TranslatableMarkup {
   $config->save();
   return t('Updated Alignment options for Bootstrap Styles.');
 }
+
+/**
+ * Give DX, Architect and manage Webform the permission to use the Webform
+ * filter format.
+ */
+function osu_standard_update_10009(&$sandbox): TranslatableMarkup {
+  $user_roles = [
+    'dx_administrator',
+    'architect',
+    'manage_webforms',
+  ];
+  foreach ($user_roles as $user_role) {
+    $role = Role::load($user_role);
+    $role->grantPermission('use text format webform_default');
+    $role->save();
+  }
+  return t('Granted permissions for DX Administrators, Architects and Manage Webforms the access to use the webform filter format.');
+}


### PR DESCRIPTION
Added 'use text format webform_default' permission for DX Administrator, Architect, and Manage Webforms user roles. Updated the configuration files and added an update hook in osu_standard.install to carry out the changes.