### PR TITLE
Enhance roles with Editoria11y permissions

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+*.theme linguist-language=PHP
+*.module linguist-language=PHP
+*.install linguist-language=PHP

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 *.theme linguist-language=PHP
 *.module linguist-language=PHP
 *.install linguist-language=PHP
+*.profile linguist-language=PHP

--- a/config/install/user.role.content_authors.yml
+++ b/config/install/user.role.content_authors.yml
@@ -15,6 +15,7 @@ dependencies:
   module:
     - captcha
     - dropzonejs
+    - editoria11y
     - exclude_node_title
     - file
     - filter
@@ -26,6 +27,7 @@ dependencies:
     - node
     - path
     - redirect
+    - system
     - toc_js_per_node
     - views_bulk_edit
 id: content_authors
@@ -36,6 +38,7 @@ permissions:
   - 'access content overview'
   - 'access files overview'
   - 'access media overview'
+  - 'access site reports'
   - 'administer nodes'
   - 'administer redirects'
   - 'administer toc_js per node'
@@ -70,7 +73,10 @@ permissions:
   - 'edit own page content'
   - 'edit own remote_video media'
   - 'exclude own node title'
+  - 'manage editoria11y results'
   - 'manage layout builder component attributes'
+  - 'mark as hidden in editoria11y'
+  - 'mark as ok in editoria11y'
   - 'revert all revisions'
   - 'revert page revisions'
   - 'skip CAPTCHA'
@@ -81,6 +87,7 @@ permissions:
   - 'use views bulk edit'
   - 'view all media revisions'
   - 'view all revisions'
+  - 'view editoria11y checker'
   - 'view media'
   - 'view own unpublished content'
   - 'view own unpublished media'

--- a/config/install/user.role.manage_blocks.yml
+++ b/config/install/user.role.manage_blocks.yml
@@ -9,9 +9,11 @@ dependencies:
     - block_visibility_groups
     - captcha
     - contextual
+    - editoria11y
     - exclude_node_title
     - honeypot
     - simple_popup_blocks
+    - system
 id: manage_blocks
 label: 'Manage Blocks'
 weight: -5
@@ -19,6 +21,7 @@ is_admin: null
 permissions:
   - 'access block library'
   - 'access contextual links'
+  - 'access site reports'
   - 'administer block classes'
   - 'administer block content'
   - 'administer block types'
@@ -26,5 +29,8 @@ permissions:
   - 'administer blocks'
   - 'administer simple_popup_blocks'
   - 'bypass honeypot protection'
+  - 'mark as hidden in editoria11y'
+  - 'mark as ok in editoria11y'
   - 'skip CAPTCHA'
   - 'use exclude node title'
+  - 'view editoria11y checker'

--- a/config/install/user.role.manage_content.yml
+++ b/config/install/user.role.manage_content.yml
@@ -16,6 +16,7 @@ dependencies:
     - captcha
     - contextual
     - dropzonejs
+    - editoria11y
     - exclude_node_title
     - file
     - filter
@@ -27,6 +28,7 @@ dependencies:
     - node
     - path
     - redirect
+    - system
     - toc_js_per_node
     - views_bulk_edit
 id: manage_content
@@ -38,6 +40,7 @@ permissions:
   - 'access contextual links'
   - 'access files overview'
   - 'access media overview'
+  - 'access site reports'
   - 'administer content types'
   - 'administer nodes'
   - 'administer redirects'
@@ -89,7 +92,10 @@ permissions:
   - 'edit own page content'
   - 'edit own remote_video media'
   - 'exclude any node title'
+  - 'manage editoria11y results'
   - 'manage layout builder component attributes'
+  - 'mark as hidden in editoria11y'
+  - 'mark as ok in editoria11y'
   - 'revert all revisions'
   - 'revert page revisions'
   - 'skip CAPTCHA'
@@ -101,6 +107,7 @@ permissions:
   - 'use views bulk edit'
   - 'view all media revisions'
   - 'view all revisions'
+  - 'view editoria11y checker'
   - 'view media'
   - 'view own unpublished content'
   - 'view own unpublished media'

--- a/osu_standard.install
+++ b/osu_standard.install
@@ -1382,3 +1382,24 @@ function osu_standard_update_10009(&$sandbox): TranslatableMarkup {
   }
   return t('Granted permissions for DX Administrators, Architects and Manage Webforms the access to use the webform filter format.');
 }
+
+/**
+ * Grant the ability to view and see editoria11y results to our content authors.
+ */
+function osu_standard_update_10010(&$sandbox): TranslatableMarkup {
+  $user_roles = [
+    'content_authors',
+    'manage_blocks',
+    'manage_content',
+  ];
+  foreach ($user_roles as $user_role) {
+    $role = Role::load($user_role);
+    $role->grantPermission('access site reports');
+    $role->grantPermission('manage editoria11y results');
+    $role->grantPermission('mark as hidden in editoria11y');
+    $role->grantPermission('mark as ok in editoria11y');
+    $role->grantPermission('view editoria11y checker');
+    $role->save();
+  }
+  return t('Granted the ability to see and use Editoria11y results to content author roles.');
+}


### PR DESCRIPTION
Added 'editoria11y' permissions to 'manage_blocks', 'content_authors', and 'manage_content' user roles. Updated the user role configuration files and implemented an update hook in osu_standard.install to apply the changes. The new permissions empower these roles with comprehensive access to view, manage, and modify Editoria11y results on the platform.