### PR TITLE
Update CAS login path in configuration

### DIFF
--- a/config/install/cas.settings.yml
+++ b/config/install/cas.settings.yml
@@ -3,7 +3,7 @@ server:
   protocol: https
   hostname: login.oregonstate.edu
   port: 443
-  path: /idp/profile/cas
+  path: /cas
   verify: 0
   cert: ''
 gateway:

--- a/osu_standard.install
+++ b/osu_standard.install
@@ -299,6 +299,18 @@ function osu_standard_update_10012(&$sandbox) {
 }
 
 /**
+ * Update the CAS login Path.
+ */
+function osu_standard_update_10013(&$sandbox): TranslatableMarkup {
+  $cas_settings = \Drupal::configFactory()->getEditable('cas.settings');
+  $cas_server_settings = $cas_settings->get('server');
+  $cas_server_settings['path'] = '/cas';
+  $cas_settings->set("server", $cas_server_settings);
+  $cas_settings->save();
+  return t("Updated CAS server login path to /cas");
+}
+
+/**
  * Installs an array of given modules.
  *
  * @param array $modules


### PR DESCRIPTION
Changed CAS server login path from '/idp/profile/cas' to '/cas' in the configuration files. Added a new update function in the install script to handle this change programmatically. This ensures consistency and simplifies future updates.