### PR TITLE
Remove admin_toolbar_links_access_filter module

### DIFF
--- a/osu_standard.info.yml
+++ b/osu_standard.info.yml
@@ -55,7 +55,6 @@ dependencies:
   - acquia_purge
   - address
   - admin_toolbar
-  - admin_toolbar_links_access_filter
   - admin_toolbar_search
   - admin_toolbar_tools
   - asset_injector


### PR DESCRIPTION
No longer required and the main module will run the uninstall once updated.