### PR TITLE
Remove DrupalFile button from CKEditor toolbar

### DIFF
--- a/config/install/editor.editor.full_html.yml
+++ b/config/install/editor.editor.full_html.yml
@@ -40,7 +40,6 @@ settings:
           items:
             - DrupalLink
             - DrupalUnlink
-            - DrupalFile
         - name: Lists
           items:
             - BulletedList
@@ -80,7 +79,7 @@ image_upload:
   status: true
   scheme: public
   directory: inline-images
-  max_size: ''
+  max_size: null
   max_dimensions:
     width: null
     height: null

--- a/config/install/filter.format.full_html.yml
+++ b/config/install/filter.format.full_html.yml
@@ -14,30 +14,30 @@ name: 'Full HTML'
 format: full_html
 weight: -50
 filters:
-  filter_align:
-    id: filter_align
-    provider: filter
-    status: true
-    weight: -50
-    settings: {  }
-  filter_caption:
-    id: filter_caption
-    provider: filter
-    status: true
-    weight: -49
-    settings: {  }
-  filter_htmlcorrector:
-    id: filter_htmlcorrector
-    provider: filter
-    status: true
-    weight: -48
-    settings: {  }
   editor_file_reference:
     id: editor_file_reference
     provider: editor
     status: true
     weight: -47
-    settings: {  }
+    settings: { }
+  filter_align:
+    id: filter_align
+    provider: filter
+    status: true
+    weight: -50
+    settings: { }
+  filter_autop:
+    id: filter_autop
+    provider: filter
+    status: false
+    weight: -41
+    settings: { }
+  filter_caption:
+    id: filter_caption
+    provider: filter
+    status: true
+    weight: -49
+    settings: { }
   filter_html:
     id: filter_html
     provider: filter
@@ -47,41 +47,24 @@ filters:
       allowed_html: '<em> <strong> <cite> <blockquote cite> <code> <ul type> <ol type start> <li> <dl> <dt> <dd> <h2 id> <h3 id> <h4 id> <h5 id> <h6 id> <sup> <sub> <drupal-media data-entity-type data-entity-uuid data-view-mode data-align data-caption alt title> <caption> <tbody> <thead> <tfoot> <th> <td> <tr> <hr> <h1> <pre> <div> <a href hreflang data-entity-type data-entity-uuid data-entity-substitution title> <table class="osu-table osu-table-orange"> <p class="display-1 display-2 display-3 display-4 display-5 fs-1 fs-2 fs-3 fs-4 fs-5 fs-6 display-1 display-2 display-3 display-4 display-5 display-6 fs-1 fs-2 fs-3 fs-4 fs-5 fs-6">'
       filter_html_help: true
       filter_html_nofollow: false
-  media_embed:
-    id: media_embed
-    provider: media
-    status: true
-    weight: -46
-    settings:
-      default_view_mode: frameless
-      allowed_view_modes:
-        frameless: frameless
-        media_card: media_card
-        osu_orange_bottom: osu_orange_bottom
-        video_720: video_720
-      allowed_media_types:
-        document: document
-        image: image
-        kaltura: kaltura
-        remote_video: remote_video
-  filter_autop:
-    id: filter_autop
-    provider: filter
-    status: false
-    weight: -41
-    settings: {  }
   filter_html_escape:
     id: filter_html_escape
     provider: filter
     status: false
     weight: -42
-    settings: {  }
+    settings: { }
   filter_html_image_secure:
     id: filter_html_image_secure
     provider: filter
     status: false
     weight: -40
-    settings: {  }
+    settings: { }
+  filter_htmlcorrector:
+    id: filter_htmlcorrector
+    provider: filter
+    status: true
+    weight: -48
+    settings: { }
   filter_url:
     id: filter_url
     provider: filter
@@ -96,3 +79,21 @@ filters:
     weight: -44
     settings:
       title: true
+  media_embed:
+    id: media_embed
+    provider: media
+    status: true
+    weight: -46
+    settings:
+      default_view_mode: frameless
+      allowed_view_modes:
+        default: default
+        frameless: frameless
+        media_card: media_card
+        osu_orange_bottom: osu_orange_bottom
+        video_720: video_720
+      allowed_media_types:
+        document: document
+        image: image
+        kaltura: kaltura
+        remote_video: remote_video

--- a/osu_standard.install
+++ b/osu_standard.install
@@ -311,6 +311,56 @@ function osu_standard_update_10013(&$sandbox): TranslatableMarkup {
 }
 
 /**
+ * Remove the DrupalFile CKEditor button.
+ */
+function osu_standard_update_10014(&$sandbox): TranslatableMarkup {
+  // Load the 'full_html' editor configuration.
+  $config_factory = \Drupal::service('config.factory');
+  $editor_config = $config_factory->getEditable('editor.editor.full_html');
+
+  if ($editor_config) {
+    // Get the current toolbar configuration.
+    $toolbar_config = $editor_config->get('settings.toolbar');
+
+    // Button to remove.
+    $button_to_remove = 'DrupalFile';
+
+    // Iterate through the toolbar configuration to find and remove the button.
+    $button_found = FALSE;
+    foreach ($toolbar_config['rows'] as &$row) {
+      foreach ($row as &$group) {
+        if (isset($group['items'])) {
+          if (($key = array_search($button_to_remove, $group['items'])) !== FALSE) {
+            unset($group['items'][$key]);
+            $group['items'] = array_values($group['items']); // Reindex the array.
+            $button_found = TRUE;
+          }
+        }
+      }
+    }
+
+    if ($button_found) {
+      // Save the updated toolbar configuration.
+      $editor_config->set('settings.toolbar', $toolbar_config);
+      $editor_config->save();
+
+      // Return a success message.
+      return t('The %button button was removed from the full_html editor toolbar.', [
+        '%button' => $button_to_remove,
+      ]);
+    }
+
+    // If the button was not found, return a message.
+    return t('The %button button was not found in the full_html editor toolbar.', [
+      '%button' => $button_to_remove,
+    ]);
+  }
+  else {
+    return t('The full_html editor configuration does not exist.');
+  }
+}
+
+/**
  * Installs an array of given modules.
  *
  * @param array $modules


### PR DESCRIPTION
Updated the 'full_html' editor configuration to remove the DrupalFile button from the toolbar. Adjusted related YAML files to reflect this change, ensuring consistency across the system.