### PR TITLE
Add Meta Image field and update Metatag defaults

### DIFF
--- a/config/install/core.entity_form_display.node.page.default.yml
+++ b/config/install/core.entity_form_display.node.page.default.yml
@@ -4,9 +4,11 @@ dependencies:
   config:
     - field.field.node.page.body
     - field.field.node.page.field_meta_tags
+    - field.field.node.page.field_osu_meta_image
     - field.field.node.page.layout_builder__layout
     - node.type.page
   module:
+    - media_library
     - metatag
     - path
     - text
@@ -24,13 +26,13 @@ content:
       summary_rows: 3
       placeholder: ''
       show_summary: false
-    third_party_settings: {  }
+    third_party_settings: { }
   created:
     type: datetime_timestamp
     weight: 10
     region: content
-    settings: {  }
-    third_party_settings: {  }
+    settings: { }
+    third_party_settings: { }
   field_meta_tags:
     type: metatag_firehose
     weight: 121
@@ -38,34 +40,41 @@ content:
     settings:
       sidebar: true
       use_details: true
-    third_party_settings: {  }
+    third_party_settings: { }
+  field_osu_meta_image:
+    type: media_library_widget
+    weight: 32
+    region: content
+    settings:
+      media_types: { }
+    third_party_settings: { }
   path:
     type: path
     weight: 30
     region: content
-    settings: {  }
-    third_party_settings: {  }
+    settings: { }
+    third_party_settings: { }
   promote:
     type: boolean_checkbox
     weight: 15
     region: content
     settings:
       display_label: true
-    third_party_settings: {  }
+    third_party_settings: { }
   status:
     type: boolean_checkbox
     weight: 120
     region: content
     settings:
       display_label: true
-    third_party_settings: {  }
+    third_party_settings: { }
   sticky:
     type: boolean_checkbox
     weight: 16
     region: content
     settings:
       display_label: true
-    third_party_settings: {  }
+    third_party_settings: { }
   title:
     type: string_textfield
     weight: -5
@@ -73,7 +82,7 @@ content:
     settings:
       size: 60
       placeholder: ''
-    third_party_settings: {  }
+    third_party_settings: { }
   uid:
     type: entity_reference_autocomplete
     weight: 5
@@ -83,11 +92,11 @@ content:
       match_limit: 10
       size: 60
       placeholder: ''
-    third_party_settings: {  }
+    third_party_settings: { }
   url_redirects:
     weight: 50
     region: content
-    settings: {  }
-    third_party_settings: {  }
+    settings: { }
+    third_party_settings: { }
 hidden:
   layout_builder__layout: true

--- a/config/install/core.entity_view_display.node.page.default.yml
+++ b/config/install/core.entity_view_display.node.page.default.yml
@@ -1,12 +1,15 @@
+uuid: 8f7569d0-e682-4b7b-8a4e-fa3bdb0ba80c
 langcode: en
 status: true
 dependencies:
   config:
     - field.field.node.page.body
     - field.field.node.page.field_meta_tags
+    - field.field.node.page.field_osu_meta_image
     - field.field.node.page.layout_builder__layout
     - node.type.page
   module:
+    - bootstrap_layout_builder
     - layout_builder
     - layout_builder_restrictions
     - metatag
@@ -17,11 +20,9 @@ third_party_settings:
     enabled: true
     allow_custom: true
     sections:
-      -
-        layout_id: 'bootstrap_layout_builder:blb_col_1'
+      - layout_id: 'bootstrap_layout_builder:blb_col_1'
         layout_settings:
           label: 'Default Page Section'
-          context_mapping: {  }
           container_wrapper_classes: ''
           container_wrapper_attributes: null
           container_wrapper:
@@ -41,8 +42,6 @@ third_party_settings:
                   background_attachment: not_fixed
                   background_size: cover
               text_color:
-                class: null
-              text_alignment:
                 class: null
               padding:
                 class: p-2
@@ -107,6 +106,8 @@ third_party_settings:
                   class: _none
               scroll_effects:
                 class: null
+              text_alignment:
+                class: null
           container_wrapper_bg_color_class: ''
           container_wrapper_bg_media: null
           container: container
@@ -115,10 +116,11 @@ third_party_settings:
           regions_classes:
             blb_region_col_1: ''
           regions_attributes:
-            blb_region_col_1: {  }
-          breakpoints: {  }
-          layout_regions_classes: {  }
+            blb_region_col_1: { }
+          breakpoints: { }
+          layout_regions_classes: { }
           remove_gutters: '0'
+          context_mapping: { }
         components:
           7d8d00f0-e477-440f-9a7d-9b56ef6aefe2:
             uuid: 7d8d00f0-e477-440f-9a7d-9b56ef6aefe2
@@ -131,10 +133,10 @@ third_party_settings:
               formatter:
                 type: text_default
                 label: hidden
-                settings: {  }
-                third_party_settings: {  }
+                settings: { }
+                third_party_settings: { }
             weight: 1
-            additional: {  }
+            additional: { }
           806578a5-9cb8-409d-a09e-b43bba4fa84b:
             uuid: 806578a5-9cb8-409d-a09e-b43bba4fa84b
             region: blb_region_col_1
@@ -144,7 +146,7 @@ third_party_settings:
               context_mapping:
                 entity: layout_builder.entity
             weight: 2
-            additional: {  }
+            additional: { }
           23050431-0772-44a7-9c25-3a8047a3c59e:
             uuid: 23050431-0772-44a7-9c25-3a8047a3c59e
             region: blb_region_col_1
@@ -156,13 +158,13 @@ third_party_settings:
               formatter:
                 type: metatag_empty_formatter
                 label: above
-                settings: {  }
-                third_party_settings: {  }
+                settings: { }
+                third_party_settings: { }
             weight: 3
-            additional: {  }
-        third_party_settings: {  }
+            additional: { }
+        third_party_settings: { }
   layout_builder_restrictions:
-    allowed_block_categories: {  }
+    allowed_block_categories: { }
     entity_view_mode_restriction:
       allowed_layouts:
         - 'bootstrap_layout_builder:blb_col_1'
@@ -171,14 +173,6 @@ third_party_settings:
         - 'bootstrap_layout_builder:blb_col_4'
         - 'bootstrap_layout_builder:blb_col_5'
         - 'bootstrap_layout_builder:blb_col_6'
-      blacklisted_blocks: {  }
-      whitelisted_blocks:
-        'Content fields':
-          - 'field_block:node:page:uid'
-          - 'field_block:node:page:created'
-          - 'field_block:node:page:body'
-          - 'field_block:node:page:field_meta_tags'
-          - 'field_block:node:page:title'
       restricted_categories:
         - 'Chaos Tools'
         - Forms
@@ -186,6 +180,14 @@ third_party_settings:
         - 'Purge UI'
         - User
         - core
+      blacklisted_blocks: { }
+      whitelisted_blocks:
+        'Content fields':
+          - 'field_block:node:page:uid'
+          - 'field_block:node:page:created'
+          - 'field_block:node:page:body'
+          - 'field_block:node:page:field_meta_tags'
+          - 'field_block:node:page:title'
     entity_view_mode_restriction_by_region:
       allowed_layouts:
         - 'bootstrap_layout_builder:blb_col_1'
@@ -202,21 +204,23 @@ content:
   body:
     type: text_default
     label: hidden
-    settings: {  }
-    third_party_settings: {  }
+    settings: { }
+    third_party_settings: { }
     weight: 100
     region: content
   field_meta_tags:
     type: metatag_empty_formatter
     label: above
-    settings: {  }
-    third_party_settings: {  }
+    settings: { }
+    third_party_settings: { }
     weight: 102
     region: blb_region_col_1
   links:
-    settings: {  }
-    third_party_settings: {  }
+    settings: { }
+    third_party_settings: { }
     weight: 101
     region: content
 hidden:
   layout_builder__layout: true
+  toc_js: true
+  field_osu_meta_image: true

--- a/config/install/core.entity_view_display.node.page.teaser.yml
+++ b/config/install/core.entity_view_display.node.page.teaser.yml
@@ -5,6 +5,7 @@ dependencies:
     - core.entity_view_mode.node.teaser
     - field.field.node.page.body
     - field.field.node.page.field_meta_tags
+    - field.field.node.page.field_osu_meta_image
     - field.field.node.page.layout_builder__layout
     - node.type.page
   module:
@@ -20,7 +21,7 @@ content:
     label: hidden
     settings:
       trim_length: 600
-    third_party_settings: {  }
+    third_party_settings: { }
     weight: 100
     region: content
   links:
@@ -28,4 +29,5 @@ content:
     region: content
 hidden:
   field_meta_tags: true
+  field_osu_meta_image: true
   layout_builder__layout: true

--- a/config/install/field.field.node.page.field_osu_meta_image.yml
+++ b/config/install/field.field.node.page.field_osu_meta_image.yml
@@ -1,0 +1,28 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_osu_meta_image
+    - media.type.image
+    - node.type.page
+id: node.page.field_osu_meta_image
+field_name: field_osu_meta_image
+entity_type: node
+bundle: page
+label: 'Meta Image'
+description: 'The image selected here will be used in the Meta-tags automatically.'
+required: false
+translatable: false
+default_value: { }
+default_value_callback: ''
+settings:
+  handler: 'default:media'
+  handler_settings:
+    target_bundles:
+      image: image
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/install/field.storage.node.field_osu_meta_image.yml
+++ b/config/install/field.storage.node.field_osu_meta_image.yml
@@ -1,4 +1,3 @@
-uuid: d43b96c3-8992-4a4a-b83f-14389f0939c2
 langcode: en
 status: true
 dependencies:

--- a/config/install/field.storage.node.field_osu_meta_image.yml
+++ b/config/install/field.storage.node.field_osu_meta_image.yml
@@ -1,0 +1,20 @@
+uuid: d43b96c3-8992-4a4a-b83f-14389f0939c2
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+    - node
+id: node.field_osu_meta_image
+field_name: field_osu_meta_image
+entity_type: node
+type: entity_reference
+settings:
+  target_type: media
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: { }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/install/metatag.metatag_defaults.global.yml
+++ b/config/install/metatag.metatag_defaults.global.yml
@@ -1,6 +1,6 @@
 langcode: en
 status: true
-dependencies: {  }
+dependencies: { }
 id: global
 label: Global
 tags:

--- a/config/install/metatag.metatag_defaults.node.yml
+++ b/config/install/metatag.metatag_defaults.node.yml
@@ -1,6 +1,6 @@
 langcode: en
 status: true
-dependencies: {  }
+dependencies: { }
 id: node
 label: Content
 tags:

--- a/config/install/metatag.metatag_defaults.node__page.yml
+++ b/config/install/metatag.metatag_defaults.node__page.yml
@@ -1,28 +1,14 @@
 langcode: en
 status: true
 dependencies: { }
-id: front
-label: 'Front page'
+id: node__page
+label: 'Content: Basic page'
 tags:
-  article_modified_time: '[node:changed:custom:c]'
-  article_published_time: '[node:created:custom:c]'
-  canonical_url: '[site:url]'
-  description: '[node:summary]'
   image_src: '[node:field_osu_meta_image:entity:field_media_image:facebook_1200x]'
-  og_description: '[node:summary]'
   og_image: '[node:field_osu_meta_image:entity:field_media_image:facebook_1200x]'
   og_image_alt: '[node:field_osu_meta_image:entity:field_media_image:alt]'
   og_image_height: '[node:field_osu_meta_image:entity:field_media_image:facebook_1200x:height]'
   og_image_type: '[node:field_osu_meta_image:entity:field_media_image:facebook_1200x:mimetype]'
   og_image_width: '[node:field_osu_meta_image:entity:field_media_image:facebook_1200x:width]'
-  og_site_name: '[site:name]'
-  og_title: '[site:name]'
-  og_type: webpage
-  og_updated_time: '[node:changed:custom:c]'
-  og_url: '[site:url]'
-  shortlink: '[site:url]'
-  title: '[site:name]'
-  twitter_cards_description: '[node:summary]'
   twitter_cards_image: '[node:field_osu_meta_image:entity:field_media_image:twitter_300x157]'
-  twitter_cards_title: '[site:name]'
   twitter_cards_type: summary_large_image

--- a/config/install/node.type.page.yml
+++ b/config/install/node.type.page.yml
@@ -29,8 +29,8 @@ third_party_settings:
     override_default: 0
 name: 'Basic page'
 type: page
-description: 'Use <em>basic pages</em> for your static content, such as an ''About us'' page.'
-help: ''
+description: "Use <em>basic pages</em> for your static content, such as an 'About us' page."
+help: null
 new_revision: true
 preview_mode: 1
 display_submitted: false

--- a/osu_standard.install
+++ b/osu_standard.install
@@ -2,12 +2,16 @@
 
 /**
  * @file
+ * The Install Profile file.
  */
 
 use Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException;
 use Drupal\Component\Plugin\Exception\PluginNotFoundException;
 use Drupal\Core\Config\FileStorage;
+use Drupal\Core\Entity\EntityStorageException;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\field\Entity\FieldConfig;
+use Drupal\field\Entity\FieldStorageConfig;
 use Drupal\shortcut\Entity\Shortcut;
 use Drupal\taxonomy\Entity\Vocabulary;
 use Drupal\user\Entity\Role;
@@ -241,8 +245,7 @@ function osu_standard_update_10008(&$sandbox): TranslatableMarkup {
 }
 
 /**
- * Give DX, Architect and manage Webform the permission to use the Webform
- * filter format.
+ * Give DX, Architect and manage Webform the permission to use the Webform filter format.
  */
 function osu_standard_update_10009(&$sandbox): TranslatableMarkup {
   $user_roles = [
@@ -294,7 +297,7 @@ function osu_standard_update_10011(&$sandbox): TranslatableMarkup {
  * Update Fontawesome icon CSN version.
  */
 function osu_standard_update_10012(&$sandbox) {
-  $fontawesome_settings = \Drupal::configFactory()
+  $fontawesome_settings = Drupal::configFactory()
     ->getEditable('fontawesome.settings');
   $fontawesome_settings->set('external_svg_location', "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css");
   $fontawesome_settings->set('external_shim_location', "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/v4-shims.min.css");
@@ -306,7 +309,7 @@ function osu_standard_update_10012(&$sandbox) {
  * Update the CAS login Path.
  */
 function osu_standard_update_10013(&$sandbox): TranslatableMarkup {
-  $cas_settings = \Drupal::configFactory()->getEditable('cas.settings');
+  $cas_settings = Drupal::configFactory()->getEditable('cas.settings');
   $cas_server_settings = $cas_settings->get('server');
   $cas_server_settings['path'] = '/cas';
   $cas_settings->set("server", $cas_server_settings);
@@ -319,7 +322,7 @@ function osu_standard_update_10013(&$sandbox): TranslatableMarkup {
  */
 function osu_standard_update_10014(&$sandbox): TranslatableMarkup {
   // Load the 'full_html' editor configuration.
-  $config_factory = \Drupal::service('config.factory');
+  $config_factory = Drupal::service('config.factory');
   $editor_config = $config_factory->getEditable('editor.editor.full_html');
 
   if ($editor_config) {
@@ -370,7 +373,7 @@ function osu_standard_update_10014(&$sandbox): TranslatableMarkup {
  */
 function osu_standard_update_10015(&$sandbox): TranslatableMarkup {
   // Load the 'full_html' filter configuration.
-  $config_factory = \Drupal::service('config.factory');
+  $config_factory = Drupal::service('config.factory');
   $editor_config = $config_factory->getEditable('filter.format.full_html');
   $editor_filters = $editor_config->get('filters');
   $media_view_modes = $editor_filters['media_embed']['settings']['allowed_view_modes'];
@@ -397,7 +400,7 @@ function osu_standard_update_10016(&$sandbox): TranslatableMarkup {
     '.block-local-tasks-block *',
     '.block-group-operations *',
   ];
-  $config_factory = \Drupal::service('config.factory');
+  $config_factory = Drupal::service('config.factory');
   $editoria11y_settings = $config_factory->getEditable('editoria11y.settings');
   $ignore_elements = array_filter(array_map('trim', explode(',', $editoria11y_settings->get('ignore_elements'))));
   $ignore_elements = array_merge($ignore_elements, $editoria11y_ignore_elements);
@@ -430,6 +433,60 @@ function osu_standard_update_10016(&$sandbox): TranslatableMarkup {
 }
 
 /**
+ * Add the Meta Image field to the Basic Page content type and set up the Metatag defautls.
+ */
+function osu_standard_update_10017(&$sandbox) {
+  $install_profile_source_path = _get_install_profile_source_path();
+
+  try {
+    FieldStorageConfig::create($install_profile_source_path->read('field.storage.node.field_osu_meta_image'))
+      ->save();
+  }
+  catch (EntityStorageException $e) {
+    Drupal::logger('osu_standard')->error($e->getMessage());
+    throw $e;
+  }
+
+  try {
+    FieldConfig::create($install_profile_source_path->read('field.field.node.page.field_osu_meta_image'))
+      ->save();
+  }
+  catch (EntityStorageException $e) {
+    Drupal::logger('osu_standard')->error($e->getMessage());
+    throw $e;
+  }
+  /** @var \Drupal\Core\Config\CachedStorage $config_storage */
+  $config_storage = Drupal::service('config.storage');
+  // Update form display.
+  $existing_node_form_display = $config_storage->read('core.entity_form_display.node.page.default');
+  $new_node_form_display = $install_profile_source_path->read('core.entity_form_display.node.page.default');
+  $existing_node_form_display['content'] = array_merge($new_node_form_display['content'], $existing_node_form_display['content']);
+  $config_storage->write('core.entity_form_display.node.page.default', $existing_node_form_display);
+  // Set the new field to hidden on the view display for the default display.
+  $node_view_display = $config_storage->read('core.entity_view_display.node.page.default');
+  unset($node_view_display['content']['field_osu_meta_image']);
+  $node_view_display['hidden']['field_osu_meta_image'] = TRUE;
+  $config_storage->write('core.entity_view_display.node.page.default', $node_view_display);
+  // Update node page metatag defaults.
+  $node_page_metatag_defaults = $config_storage->read('metatag.metatag_defaults.node__page');
+  if ($node_page_metatag_defaults === FALSE) {
+    $config_storage->write('metatag.metatag_defaults.node__page', $install_profile_source_path->read('metatag.metatag_defaults.node__page'));
+  }
+  else {
+    $new_node_metatag_defaults = $install_profile_source_path->read('metatag.metatag_defaults.node__page');
+    $node_page_metatag_defaults['tags'] = array_merge($new_node_metatag_defaults['tags'], $node_page_metatag_defaults['tags']);
+    $config_storage->write('metatag.metatag_defaults.node__page', $node_page_metatag_defaults);
+  }
+  // Update front page metatag defaults.
+  $font_metatag_defaults = $config_storage->read('metatag.metatag_defaults.front');
+  $new_front_metatag_defaults = $install_profile_source_path->read('metatag.metatag_defaults.front');
+  $font_metatag_defaults['tags'] = array_merge($new_front_metatag_defaults['tags'], $font_metatag_defaults['tags']);
+  $config_storage->write('metatag.metatag_defaults.front', $font_metatag_defaults);
+
+  return t('Added new metatag field for node and updated the metatag defaults');
+}
+
+/**
  * Installs an array of given modules.
  *
  * @param array $modules
@@ -441,9 +498,9 @@ function osu_standard_update_10016(&$sandbox): TranslatableMarkup {
  */
 function osu_standard_install_modules(array $modules): void {
   // Load the module handler and module installer services.
-  $module_handler = \Drupal::moduleHandler();
+  $module_handler = Drupal::moduleHandler();
   /** @var \Drupal\Core\ProxyClass\Extension\ModuleInstaller $module_installer */
-  $module_installer = \Drupal::service('module_installer');
+  $module_installer = Drupal::service('module_installer');
 
   foreach ($modules as $module) {
     // Check if the module is already enabled.
@@ -480,4 +537,19 @@ function osu_standard_grant_permissions(array $roles, array $permissions): void 
     Drupal::logger('osu_standard')->error($e->getMessage());
     throw new Exception('Unable to load user role storage.');
   }
+}
+
+/**
+ * Retrieves the source path for the install profile configuration.
+ *
+ * @return \Drupal\Core\Config\FileStorage
+ *   The FileStorage instance containing the path to the install profile
+ *   configuration.
+ */
+function _get_install_profile_source_path(): FileStorage {
+  $install_profile_path = Drupal::service('module_handler')
+    ->getModule('osu_standard')
+    ->getPath();
+  $config_path = realpath($install_profile_path . '/config/install');
+  return new FileStorage($config_path);
 }


### PR DESCRIPTION
Introduced a new Meta Image field to the Basic Page content type. Updated various configurations to incorporate this field and adjusted Metatag defaults for node and front page to utilize the new Meta Image data.