### PR TITLE
Remove Google Analytics module and related permissions

### DIFF
--- a/config/install/user.role.architect.yml
+++ b/config/install/user.role.architect.yml
@@ -38,7 +38,6 @@ dependencies:
     - field_ui
     - file
     - filter
-    - google_analytics
     - google_tag
     - honeypot
     - image
@@ -121,7 +120,6 @@ permissions:
   - 'administer feeds'
   - 'administer feeds_tamper'
   - 'administer filters'
-  - 'administer google analytics'
   - 'administer google tag manager'
   - 'administer honeypot'
   - 'administer image styles'

--- a/config/install/user.role.dx_administrator.yml
+++ b/config/install/user.role.dx_administrator.yml
@@ -41,7 +41,6 @@ dependencies:
     - file
     - filter
     - fontawesome
-    - google_analytics
     - google_cse
     - google_tag
     - honeypot
@@ -108,7 +107,6 @@ permissions:
   - 'access webform help'
   - 'access webform overview'
   - 'access webform submission user'
-  - 'add JS snippets for google analytics'
   - 'add section library templates'
   - 'administer CAPTCHA settings'
   - 'administer account settings'
@@ -137,7 +135,6 @@ permissions:
   - 'administer feeds_feed_type labels'
   - 'administer feeds_tamper'
   - 'administer filters'
-  - 'administer google analytics'
   - 'administer google tag manager'
   - 'administer honeypot'
   - 'administer image styles'
@@ -287,7 +284,6 @@ permissions:
   - 'mark as hidden in editoria11y'
   - 'mark as ok in editoria11y'
   - 'notify of path changes'
-  - 'opt-in or out of google analytics tracking'
   - 'override xmlsitemap link settings'
   - 'revert all revisions'
   - 'search Google CSE'
@@ -298,7 +294,6 @@ permissions:
   - 'synchronize configuration'
   - 'update any media'
   - 'update media'
-  - 'use PHP for google analytics tracking visibility'
   - 'use advanced search'
   - 'use bulk_image bulk upload form'
   - 'use exclude node title'

--- a/config/install/user.role.manage_site_configuration.yml
+++ b/config/install/user.role.manage_site_configuration.yml
@@ -35,7 +35,6 @@ permissions:
   - 'administer ap style settings'
   - 'administer crop types'
   - 'administer easy breadcrumb'
-  - 'administer google analytics'
   - 'administer google tag manager'
   - 'administer honeypot'
   - 'administer linkit profiles'

--- a/osu_standard.info.yml
+++ b/osu_standard.info.yml
@@ -94,7 +94,6 @@ dependencies:
   - filter_perms
   - focal_point
   - fontawesome
-  - google_analytics
   - google_cse
   - google_tag
   - honeypot


### PR DESCRIPTION
Google Analytics module references and permissions were removed from multiple roles and configuration files. This change streamlines the codebase by eliminating unused or obsolete dependencies and simplifies role-based permissions.