### PR TITLE
Enable Responsive Table filter in Full HTML editor

### DIFF
--- a/config/install/filter.format.full_html.yml
+++ b/config/install/filter.format.full_html.yml
@@ -10,15 +10,16 @@ dependencies:
     - editor
     - linkit
     - media
+    - responsive_table_filter
 name: 'Full HTML'
 format: full_html
-weight: -50
+weight: -10
 filters:
   editor_file_reference:
     id: editor_file_reference
     provider: editor
-    status: true
-    weight: -47
+    status: false
+    weight: -41
     settings: { }
   filter_align:
     id: filter_align
@@ -29,8 +30,8 @@ filters:
   filter_autop:
     id: filter_autop
     provider: filter
-    status: false
-    weight: -41
+    status: true
+    weight: -44
     settings: { }
   filter_caption:
     id: filter_caption
@@ -42,48 +43,62 @@ filters:
     id: filter_html
     provider: filter
     status: false
-    weight: -43
+    weight: -40
     settings:
-      allowed_html: '<em> <strong> <cite> <blockquote cite> <code> <ul type> <ol type start> <li> <dl> <dt> <dd> <h2 id> <h3 id> <h4 id> <h5 id> <h6 id> <sup> <sub> <drupal-media data-entity-type data-entity-uuid data-view-mode data-align data-caption alt title> <caption> <tbody> <thead> <tfoot> <th> <td> <tr> <hr> <h1> <pre> <div> <a href hreflang data-entity-type data-entity-uuid data-entity-substitution title> <table class="osu-table osu-table-orange"> <p class="display-1 display-2 display-3 display-4 display-5 fs-1 fs-2 fs-3 fs-4 fs-5 fs-6 display-1 display-2 display-3 display-4 display-5 display-6 fs-1 fs-2 fs-3 fs-4 fs-5 fs-6">'
+      allowed_html: '<em> <strong> <cite> <blockquote cite> <code> <ul type> <ol type start> <li> <dl> <dt> <dd> <h3 id> <h4 id> <h5 id> <h6 id> <s> <sup> <sub> <caption> <tbody> <thead> <tfoot> <th> <td> <tr> <hr> <h1> <pre> <div> <drupal-media data-entity-type data-entity-uuid data-view-mode data-align data-caption alt title> <h2 id class="text-osuorange"> <a href hreflang data-entity-substitution data-entity-type data-entity-uuid title> <table class="osu-table osu-table-orange"> <p class="fs-1 fs-2 fs-3 fs-4 fs-5 fs-6 display-1 display-2 display-3 display-4 display-5 fs-1 fs-2 fs-3 fs-4 fs-5 fs-6">'
       filter_html_help: true
       filter_html_nofollow: false
   filter_html_escape:
     id: filter_html_escape
     provider: filter
     status: false
-    weight: -42
+    weight: -39
     settings: { }
   filter_html_image_secure:
     id: filter_html_image_secure
     provider: filter
     status: false
-    weight: -40
+    weight: -38
     settings: { }
   filter_htmlcorrector:
     id: filter_htmlcorrector
     provider: filter
     status: true
-    weight: -48
+    weight: -42
     settings: { }
+  filter_image_lazy_load:
+    id: filter_image_lazy_load
+    provider: filter
+    status: true
+    weight: -43
+    settings: { }
+  filter_responsive_table:
+    id: filter_responsive_table
+    provider: responsive_table_filter
+    status: true
+    weight: -45
+    settings:
+      wrapper_element: div
+      wrapper_classes: table-responsive
   filter_url:
     id: filter_url
     provider: filter
     status: true
-    weight: -45
+    weight: -47
     settings:
       filter_url_length: 72
   linkit:
     id: linkit
     provider: linkit
     status: true
-    weight: -44
+    weight: -46
     settings:
       title: true
   media_embed:
     id: media_embed
     provider: media
     status: true
-    weight: -46
+    weight: -48
     settings:
       default_view_mode: frameless
       allowed_view_modes:

--- a/osu_standard.install
+++ b/osu_standard.install
@@ -530,6 +530,50 @@ function osu_standard_update_10020(&$sandbox): TranslatableMarkup {
 }
 
 /**
+ * Enable and use the Responsive Table filter plugin.
+ */
+function osu_standard_update_10021(&$sandbox): TranslatableMarkup {
+  osu_standard_install_modules(['responsive_table_filter']);
+  /** @var \Drupal\Core\Config\ConfigFactory $editor_config */
+  $config_factory = Drupal::service('config.factory');
+  /** @var \Drupal\Core\Config\Config $editor_config */
+  $editor_config = $config_factory->getEditable('filter.format.full_html');
+  /** @var array $editor_filters */
+  $editor_filters = $editor_config->get('filters');
+  $filter_responsive_table = [
+    "id" => "filter_responsive_table",
+    "provider" => "responsive_table_filter",
+    "status" => TRUE,
+    "weight" => -45,
+    "settings" => [
+      "wrapper_element" => "div",
+      "wrapper_classes" => "table-responsive",
+    ],
+  ];
+  $editor_filters["filter_responsive_table"] = $filter_responsive_table;
+  $editor_filters["filter_autop"]["status"] = TRUE;
+  $editor_filters["editor_file_reference"]["status"] = FALSE;
+
+  // Reset weights of our plugins
+  $editor_filters["editor_file_reference"]["weight"] = -41;
+  $editor_filters["filter_align"]["weight"] = -50;
+  $editor_filters["filter_autop"]["weight"] = -44;
+  $editor_filters["filter_caption"]["weight"] = -49;
+  $editor_filters["filter_html"]["weight"] = -40;
+  $editor_filters["filter_html_escape"]["weight"] = -39;
+  $editor_filters["filter_html_image_secure"]["weight"] = -38;
+  $editor_filters["filter_htmlcorrector"]["weight"] = -42;
+  $editor_filters["filter_image_lazy_load"]["weight"] = -43;
+  $editor_filters["filter_url"]["weight"] = -47;
+  $editor_filters["linkit"]["weight"] = -46;
+  $editor_filters["media_embed"]["weight"] = -48;
+
+  $editor_config->set("filters", $editor_filters);
+  $editor_config->save();
+  return t('Enabled Responsive Table filter plugin');
+}
+
+/**
  * Installs an array of given modules.
  *
  * @param array $modules

--- a/osu_standard.install
+++ b/osu_standard.install
@@ -550,7 +550,15 @@ function osu_standard_update_10021(&$sandbox): TranslatableMarkup {
       "wrapper_classes" => "table-responsive",
     ],
   ];
+  $filter_image_lazy_load = [
+    "id" => "filter_image_lazy_load",
+    "provider" => "filter",
+    "status" => TRUE,
+    "weight" => -43,
+    "settings" => [],
+  ];
   $editor_filters["filter_responsive_table"] = $filter_responsive_table;
+  $editor_filters["filter_image_lazy_load"] = $filter_image_lazy_load;
   $editor_filters["filter_autop"]["status"] = TRUE;
   $editor_filters["editor_file_reference"]["status"] = FALSE;
 


### PR DESCRIPTION
Added the Responsive Table filter plugin to the Full HTML text format and configured its settings. Adjusted weights and statuses of other filters for compatibility and improved filter ordering. This update enhances table rendering by making them responsive within the editor.