### PR TITLE
Remove "sitewide alert" permissions and add "madrone theme" permissions.

### DIFF
--- a/config/install/user.role.architect.yml
+++ b/config/install/user.role.architect.yml
@@ -155,8 +155,6 @@ permissions:
   - 'administer shortcuts'
   - 'administer simple_popup_blocks'
   - 'administer site configuration'
-  - 'administer sitewide alert'
-  - 'administer sitewide alert entities'
   - 'administer smart date formats'
   - 'administer taxonomy'
   - 'administer taxonomy_term display'

--- a/config/install/user.role.dx_administrator.yml
+++ b/config/install/user.role.dx_administrator.yml
@@ -59,6 +59,7 @@ dependencies:
     - node
     - node_revision_delete
     - oembed_providers
+    - osu_roles
     - paragraphs
     - path
     - pathauto
@@ -148,6 +149,7 @@ permissions:
   - 'administer layout builder component attributes'
   - 'administer linkit profiles'
   - 'administer linkpurpose'
+  - 'administer madrone theme'
   - 'administer media'
   - 'administer media display'
   - 'administer media fields'

--- a/config/install/user.role.manage_site_configuration.yml
+++ b/config/install/user.role.manage_site_configuration.yml
@@ -22,7 +22,6 @@ dependencies:
     - search
     - shortcut
     - simple_popup_blocks
-    - sitewide_alert
     - smart_date
     - system
     - toc_js
@@ -44,6 +43,7 @@ permissions:
   - 'administer honeypot'
   - 'administer linkit profiles'
   - 'administer linkpurpose'
+  - 'administer madrone theme'
   - 'administer menu'
   - 'administer node_revision_delete'
   - 'administer pathauto'
@@ -54,8 +54,6 @@ permissions:
   - 'administer shortcuts'
   - 'administer simple_popup_blocks'
   - 'administer site configuration'
-  - 'administer sitewide alert'
-  - 'administer sitewide alert entities'
   - 'administer smart date formats'
   - 'administer themes'
   - 'administer toc_js'

--- a/osu_standard.install
+++ b/osu_standard.install
@@ -611,10 +611,7 @@ function osu_standard_update_10022(&$sandbox): TranslatableMarkup {
   $view_roles = ['anonymous', 'authenticated'];
   $view_perm = 'view published sitewide alert entities';
   $manage_roles = [
-    'administrator',
     'dx_administrator',
-    'architect',
-    'manage_site_configuration',
   ];
   $manage_perms = [
     'administer sitewide alert',
@@ -623,8 +620,6 @@ function osu_standard_update_10022(&$sandbox): TranslatableMarkup {
   $full_access_roles = ['dx_administrator', 'architect'];
   $full_access_perms = [
     'add sitewide alert entities',
-    'administer sitewide alert',
-    'administer sitewide alert entities',
     'delete all sitewide alert revisions',
     'delete sitewide alert entities',
     'edit sitewide alert entities',
@@ -651,6 +646,16 @@ function osu_standard_update_10023(&$sandbox) {
   $fontawesome_settings->set('external_shim_location', 'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.7.2/css/v4-shims.min.css');
   $fontawesome_settings->save();
   return t('Updated FontAwesome version');
+}
+
+/**
+ * Grant new permissions for osu_roles
+ */
+function osu_standard_update_10024(&$sandbox): TranslatableMarkup {
+  $theme_admin = ['dx_administrator', 'architect', 'manage_site_configuration'];
+  $theme_admin_perms = ['administer madrone theme'];
+  osu_standard_grant_permissions($theme_admin, $theme_admin_perms);
+  return t('Granted new permissions for osu_roles');
 }
 
 /**


### PR DESCRIPTION
Eliminated outdated "sitewide alert" permissions from multiple roles and updated role configurations accordingly. Introduced new "madrone theme" permission for relevant roles to grant administrative access. Additionally, included necessary updates in the installation script for role permissions.