### PR TITLE
Disable `filter_autop` and adjust Editoria11y settings.

### DIFF
--- a/config/install/editoria11y.settings.yml
+++ b/config/install/editoria11y.settings.yml
@@ -1,5 +1,6 @@
 content_root: ''
 no_load: ''
+ignore_all_if_absent: ''
 ignore_elements: '.filter-guidelines-item *,#toolbar-administration *,nav *,.block-local-tasks-block *,.block-group-operations *'
 embedded_content_warning: ''
 assertiveness: 'smart'
@@ -8,10 +9,10 @@ ignore_link_strings: ''
 link_strings_new_windows: ''
 link_ignore_selector: 'svg.ext, svg.mailto, .link-purpose-text'
 hidden_handlers: ''
-ignore_all_if_absent: ''
-ed11y_theme: 'sleekTheme'
+ed11y_theme: sleekTheme
 shadow_components: ''
 disable_sync: false
 preserve_params: 'search,keys,page,language,language_content_entity'
-custom_tests: 1
 redundant_prefix: ''
+custom_tests: 1
+ck5_table_headers: row

--- a/config/install/filter.format.full_html.yml
+++ b/config/install/filter.format.full_html.yml
@@ -30,7 +30,7 @@ filters:
   filter_autop:
     id: filter_autop
     provider: filter
-    status: true
+    status: false
     weight: -44
     settings: { }
   filter_caption:

--- a/config/install/filter.format.restricted_html.yml
+++ b/config/install/filter.format.restricted_html.yml
@@ -19,7 +19,7 @@ filters:
   filter_autop:
     id: filter_autop
     provider: filter
-    status: true
+    status: false
     weight: 0
     settings: {  }
   filter_url:


### PR DESCRIPTION
Turned off `filter_autop` in both `restricted_html` and `full_html` formats for consistency. Updated Editoria11y settings with additional options including `ck5_table_headers` and `ignore_all_if_absent`. Corrected YAML formatting for `ed11y_theme`.