### PR TITLE
Update Permissions for Sitewide Alerts.

### DIFF
--- a/config/install/user.role.alert_author.yml
+++ b/config/install/user.role.alert_author.yml
@@ -13,6 +13,7 @@ weight: 5
 is_admin: null
 permissions:
   - 'add sitewide alert entities'
+  - 'administer sitewide alert entities'
   - 'delete sitewide alert entities'
   - 'edit sitewide alert entities'
   - 'revert all sitewide alert revisions'

--- a/config/install/user.role.architect.yml
+++ b/config/install/user.role.architect.yml
@@ -155,6 +155,7 @@ permissions:
   - 'administer shortcuts'
   - 'administer simple_popup_blocks'
   - 'administer site configuration'
+  - 'administer sitewide alert entities'
   - 'administer smart date formats'
   - 'administer taxonomy'
   - 'administer taxonomy_term display'

--- a/osu_standard.install
+++ b/osu_standard.install
@@ -659,6 +659,22 @@ function osu_standard_update_10024(&$sandbox): TranslatableMarkup {
 }
 
 /**
+ * Update permissions for the Sitewide Alerts.
+ */
+function osu_standard_update_10025(&$sandbox): TranslatableMarkup {
+  $roles = ['architect', 'alert_author'];
+  $perm = 'administer sitewide alert entities';
+
+  foreach ($roles as $role) {
+    $sitewide_update_role = Role::load($role);
+    $sitewide_update_role->grantPermission($perm);
+    $sitewide_update_role->save();
+  }
+
+  return t('Updated permissions for the Sitewide Alerts');
+}
+
+/**
  * Installs an array of given modules.
  *
  * @param array $modules


### PR DESCRIPTION
Grant "administer sitewide alert entities" permission to "architect" and "alert_author" roles.

Updated role configuration and installation script to include the new permission for managing sitewide alert entities.