### PR TITLE
Update `exclude_node_title` configuration and add update hook (10026). Adjust `type` to `remove` and clear `nid_list`.

### DIFF
--- a/config/install/exclude_node_title.settings.yml
+++ b/config/install/exclude_node_title.settings.yml
@@ -1,8 +1,6 @@
-nid_list:
-  - 2
 translation_sync: true
 search: true
-type: hidden
+type: remove
 content_types:
   page: user
   osu_profile: all

--- a/osu_standard.install
+++ b/osu_standard.install
@@ -675,6 +675,22 @@ function osu_standard_update_10025(&$sandbox): TranslatableMarkup {
 }
 
 /**
+ * Update configs with new changes.
+ *
+ * Updating Exclude node title
+ */
+function osu_standard_update_10026(&$sandbox) {
+  /** @var \Drupal\Core\Config\ConfigFactory $config_factory */
+  $config_factory = Drupal::service('config.factory');
+  /** @var \Drupal\Core\Config\Config $exclude_node_title */
+  $exclude_node_title = $config_factory->getEditable('exclude_node_title.settings');
+  $exclude_node_title->set('type', 'remove');
+  $exclude_node_title->clear('nid_list');
+  $exclude_node_title->save();
+  return t('Updated configs with new changes');
+}
+
+/**
  * Installs an array of given modules.
  *
  * @param array $modules


### PR DESCRIPTION
Update to change how the exclude node title is operated to work properly with sites and our editoria11y code.